### PR TITLE
Option to use volume keys to control media volume anytime (1/2)

### DIFF
--- a/res/values/deso_strings.xml
+++ b/res/values/deso_strings.xml
@@ -326,5 +326,9 @@
     <!-- Recents Membar -->
     <string name="recents_mem_display_title">Show memory bar</string>
     <string name="recents_mem_display_summary">Show available RAM in recents</string>
+
+    <!-- Volume key controls media stream -->
+    <string name="volume_keys_control_media_stream_title">Volume keys control media volume</string>
+    <string name="volume_keys_control_media_stream_summary">Force volume keys to control media stream</string>
   
 </resources>

--- a/res/xml/button_settings.xml
+++ b/res/xml/button_settings.xml
@@ -21,6 +21,12 @@
         android:entries="@array/wired_ringtone_focus_mode_entries"
         android:entryValues="@array/wired_ringtone_focus_mode_values" />
 
+    <com.android.settings.preference.SystemSettingSwitchPreference
+        android:key="volume_keys_control_media_stream"
+        android:title="@string/volume_keys_control_media_stream_title"
+        android:summary="@string/volume_keys_control_media_stream_summary"
+        android:defaultValue="false" />
+
     <SwitchPreference
         android:key="swap_volume_buttons"
         android:title="@string/swap_volume_buttons_title"


### PR DESCRIPTION
Some users don't adjust ringtone volume often (e.g. only use toggle to
switch between silent and non-silent) mode. Having an option to
use the volume keys to control media volume anytime allows media
volume to be controllled/muted before entering a game or other apps
with sound in an undesirable location.

Change-Id: I940cd6c1d00dccf3fd01d37788ca72459db997bd